### PR TITLE
for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

### DIFF
--- a/src/utiles/lazyLoad.js
+++ b/src/utiles/lazyLoad.js
@@ -1,6 +1,7 @@
 import {lazy} from 'react';
 
 export function lazyLoad(file){
-     return lazy(()=> import(`../components/${file}`))
+     
+     return lazy(()=> import(/* @vite-ignore */`../components/${file}`))
    
 }


### PR DESCRIPTION
Solve